### PR TITLE
Don't rely on default postgres user or pip internals for tests

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 requests==2.18.4
 six==1.11.0
-https://github.com/signalfx/collectd-common/archive/utils-v0.0.1.zip#subdirectory=utils
+https://github.com/signalfx/collectd-common/archive/utils-v0.0.2.zip#subdirectory=utils

--- a/test/integration/conftest.py
+++ b/test/integration/conftest.py
@@ -1,11 +1,12 @@
 from shutil import copyfile, rmtree
+from subprocess import check_call
 from tempfile import mkdtemp
 from textwrap import dedent
 from io import BytesIO
+import sys
 import os
 
 from collectdtesting.containers import get_docker_client
-from pip._internal import main as pipmain
 import pytest
 
 
@@ -20,8 +21,10 @@ def collectd_kong():
         kong = absjoin(__file__, '../../')
         plugin = absjoin(__file__, '../../kong_plugin.py')
         tgt = mkdtemp()
-        pipmain(['install', '--upgrade', '--target', tgt, kong])
-        pipmain(['install', '--upgrade', '--target', tgt + '/kong', '-r', pkgs])
+        check_call([sys.executable, '-m', 'pip', 'install', '--upgrade',
+                    '--target', tgt, kong])
+        check_call([sys.executable, '-m', 'pip', 'install', '--upgrade',
+                    '--target', tgt + '/kong', '-r', pkgs])
         copyfile(plugin, tgt + '/kong_plugin.py')
         yield tgt
     finally:

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -1,4 +1,4 @@
 pytest
 requests==2.18.4
 six==1.11.0
-https://github.com/signalfx/collectd-common/archive/utils-v0.0.1.zip#subdirectory=utils
+https://github.com/signalfx/collectd-common/archive/utils-v0.0.2.zip#subdirectory=utils


### PR DESCRIPTION
Postgres docker image has introduced breaking change: https://github.com/docker-library/postgres/commit/3f585c58df93e93b730c09a13e8904b96fa20c58

Also makes direct call to pip instead of using internals.

Also bumps collectd-common utils version to remove invalid error.